### PR TITLE
Changed MIRIRampData to RampData. Don't copy DATAMODL, FILETYPE, FILE…

### DIFF
--- a/datamodels/ancestry.py
+++ b/datamodels/ancestry.py
@@ -12,6 +12,7 @@ the DATAMODL metadata.
 30 Jan 2019: Created
 22 Mar 2019: Return a blank string when a data model does not have an
              STScI equivalent.
+13 Dec 2019: MIRIRampModel replaced with RampModel.
 
 
 @author: Steven Beard (UKATC)
@@ -26,8 +27,8 @@ the DATAMODL metadata.
 #       Uncertain mappings are commented out.
 #
 PARENT_DICT = {'MiriDataModel' : 'DataModel', \
-               'MiriRampModel' : 'MIRIRampModel', \
-               'MiriExposureModel' : 'MIRIRampModel', \
+               'MiriRampModel' : 'RampModel', \
+               'MiriExposureModel' : 'RampModel', \
                'MiriSlopeModel' : 'ImageModel', \
                'MiriMrsApertureCorrectionModel' : '', \
                'MiriBadPixelMaskModel' :    'MaskModel', \

--- a/datamodels/miri_model_base.py
+++ b/datamodels/miri_model_base.py
@@ -182,6 +182,8 @@ https://jwst-pipeline.readthedocs.io/en/latest/jwst/datamodels/index.html
 04 Oct 2019: MIR_DARK exposure type has changed to MIR_DARKALL, MIR_DARKIMG
              and MIR_DARKMRS.
 07 Oct 2019: Removed '.yaml' suffix from schema references.
+13 Dec 2019: Modified copy_metadata to prevent DATAMODL, FILETYPE, FILENAME
+             and REFTYPE keywords being copied.
 
 @author: Steven Beard (UKATC), Vincent Geers (UKATC)
 
@@ -1571,7 +1573,7 @@ class MiriDataModel(DataModel):
         NOTE: This method will only copy the metadata defined in the
         schemas for both the current and "other" data models. Other
         metadata will be ignored (and a warning issued). Use the 'ignore'
-        parameter to specify keywords that are know to be missing or
+        parameter to specify keywords that are known to be missing or
         irrelevant.
 
         :Parameters:
@@ -1585,6 +1587,9 @@ class MiriDataModel(DataModel):
         """
         assert isinstance(other, MiriDataModel)
         if hasattr(other, 'meta'):
+            # The following keywords are fundamental to the data type
+            # and must never be copied.
+            alwaysignore = ['DATAMODL', 'FILETYPE', 'REFTYPE', 'FILENAME']
 
             # Copy all metadata apart from keyword matches specified
             # in the ignore list.
@@ -1594,7 +1599,7 @@ class MiriDataModel(DataModel):
             names = []
             for key in metakeys:
                 tobecopied = True
-                for ignorekw in ignore:
+                for ignorekw in ignore+alwaysignore:
                     if ignorekw and (ignorekw in key):
                         # Skip to the next keyword
                         tobecopied = False

--- a/datamodels/schemas/miri_ramp_withmeta.schema.yaml
+++ b/datamodels/schemas/miri_ramp_withmeta.schema.yaml
@@ -7,4 +7,4 @@ allOf:
   properties:
     meta:
       $ref: miri_metadata_dataerr.schema.yaml
-- $ref: http://stsci.edu/schemas/jwst_datamodel/miri_ramp.schema
+- $ref: http://stsci.edu/schemas/jwst_datamodel/ramp.schema


### PR DESCRIPTION
Modifications in response to Bug 621.

SCASim copies metadata from the illumination model to the ramp data, and in
this case the FILETYPE and DATAMODL keywords in the output file were being
overwritten by the ones defined in the illumination model
(FILETYPE='ILLUMINATION' and DATAMODL=' ').
I have modified the metadata copying function so that keywords which are
fundamental to the data model are not copied.