### PR TITLE
MIRI-732: fix typos in data model of MRS Spectral Resolution CDP.

### DIFF
--- a/datamodels/schemas/miri_spectral_spatial_resolution_mrs.schema.yaml
+++ b/datamodels/schemas/miri_spectral_spatial_resolution_mrs.schema.yaml
@@ -460,7 +460,7 @@ allOf:
         datatype: float64
       - name: DLSF_WID
         datatype: float64
-      - name: DSLF_NO_ETA_WID
+      - name: DLSF_NO_ETA_WID
         datatype: float64
       - name: MLSF_WIDTH
         datatype: float64
@@ -478,7 +478,7 @@ allOf:
         datatype: float64
       - name: s
         datatype: float64
-      - name: co
+      - name: c0
         datatype: float64
       - name: c1
         datatype: float64


### PR DESCRIPTION
I came across these two typos while running the CDP verification script against the MRS Spectral Resolution files for CDP-7.
