### PR TITLE
Check scasim read noise

### DIFF
--- a/datamodels/schemas/miri_metadata_sim.schema.yaml
+++ b/datamodels/schemas/miri_metadata_sim.schema.yaml
@@ -69,28 +69,28 @@ properties:
         fits_keyword: EXPTIME
       read_noise:
         type: number
-        title: Mean simulated read noise (electrons)
+        title: Mean simulated read noise (DN)
         fits_keyword: RDNOISE
       read_noise1:
         type: number
-        title: Simulated read noise for amplifier 1 (electrons)
+        title: Simulated read noise for amplifier 1 (DN)
         fits_keyword: RDNOISE1
       read_noise2:
         type: number
-        title: Simulated read noise for amplifier 2 (electrons)
+        title: Simulated read noise for amplifier 2 (DN)
         fits_keyword: RDNOISE2
       read_noise3:
         type: number
-        title: Simulated read noise for amplifier 3 (electrons)
+        title: Simulated read noise for amplifier 3 (DN)
         fits_keyword: RDNOISE3
       read_noise4:
         type: number
-        title: Simulated read noise for amplifier 4 (electrons)
+        title: Simulated read noise for amplifier 4 (DN)
         fits_keyword: RDNOISE4
       read_noise5:
         type: number
-        title: Simulated read noise for amplifier 5 (electrons)
-        fits_keyword: RDNOISE1
+        title: Simulated read noise for amplifier 5 (DN)
+        fits_keyword: RDNOISE5
       read_bias:
         type: number
         title: Mean simulated bias (electrons)
@@ -105,15 +105,15 @@ properties:
         fits_keyword: RDBIAS2
       read_bias3:
         type: number
-        title: Simulated bias for amplifier 2 (electrons)
+        title: Simulated bias for amplifier 3 (electrons)
         fits_keyword: RDBIAS3
       read_bias4:
         type: number
-        title: Simulated bias for amplifier 2 (electrons)
+        title: Simulated bias for amplifier 4 (electrons)
         fits_keyword: RDBIAS4
       read_bias5:
         type: number
-        title: Simulated bias for amplifier 2 (electrons)
+        title: Simulated bias for amplifier 5 (electrons)
         fits_keyword: RDBIAS5
       amplifier_gain_function:
         type: string
@@ -130,19 +130,19 @@ properties:
         fits_keyword: GAINCF1
       amplifier_gain2:
         type: number
-        title: Simulated gain coefficient for amplifier 1 (e/DN)
+        title: Simulated gain coefficient for amplifier 2 (e/DN)
         fits_keyword: GAINCF2
       amplifier_gain3:
         type: number
-        title: Simulated gain coefficient for amplifier 1 (e/DN)
+        title: Simulated gain coefficient for amplifier 3 (e/DN)
         fits_keyword: GAINCF3
       amplifier_gain4:
         type: number
-        title: Simulated gain coefficient for amplifier 1 (e/DN)
+        title: Simulated gain coefficient for amplifier 4 (e/DN)
         fits_keyword: GAINCF4
       amplifier_gain5:
         type: number
-        title: Simulated gain coefficient for amplifier 1 (e/DN)
+        title: Simulated gain coefficient for amplifier 5 (e/DN)
         fits_keyword: GAINCF5
       amplifier_dynamic_range:
         title: Mean simulated dynamic range (DN)

--- a/simulators/integrators.py
+++ b/simulators/integrators.py
@@ -779,7 +779,8 @@ class PoissonIntegrator(object):
             min = np.min( readout_array )
             max = np.max( readout_array )
             mean = np.mean( readout_array )
-            self.logger.debug("   min=%.1f, max=%.1f, mean=%.1f" % (min, max, mean))
+            std = np.std( readout_array )
+            self.logger.debug("   min=%.1f, max=%.1f, mean=%.2f, std=%.2f" % (min, max, mean, std))
         
         # Return the readout converted to int to make a discrete count.
         return readout_array.astype(np.uint32)

--- a/simulators/scasim/detector.py
+++ b/simulators/scasim/detector.py
@@ -233,6 +233,9 @@ Calibration Data Products (CDPs).
 04 Jun 2018: Added hard_reset function.
 15 Jan 2019: Added explicit garbage collection (commented out for now).
 07 Feb 2019: Added cdp_ftp_host parameter.
+23 Jan 2020: Do not reduce read noise by nsamples in SLOW mode.
+             Record mean read noise in the FITS header in DN rather than 
+             electrons.
 
 @author: Steven Beard (UKATC), Vincent Geers (UKATC)
 

--- a/simulators/scasim/detector.py
+++ b/simulators/scasim/detector.py
@@ -2161,7 +2161,10 @@ class DetectorArray(object):
                 # Only determine the mean read noise in non-zero areas
                 # (i.e. skipping non-illuminated  pixels)
                 valid_rn = np.where(self.readnoise_map > 0.0)
-                mean_gain = max(0.001, self.gain_map.mean())
+                if self.gain_map is not None:
+                    mean_gain = max(0.001, self.gain_map.mean())
+                else:
+                    mean_gain = 1.0
                 mean_rn = self.readnoise_map[valid_rn].mean() / mean_gain
                 metadata["RDNOISE"] = float("%.4f" % mean_rn)
                 if comments_possible and (self.noise_factor != 1.0):


### PR DESCRIPTION
Merge the check_scasim_read_noise branch with master before the changes made are overlooked.

The read noise in SLOW mode is no longer reduced by the number of samples and the mean noise recorded in the FITS header of the ramp data is recorded in units of pixels. The branch can remain open in case there are further developments in ticket MIRI-703.