### PR TITLE
JWST B7.5 compatibility updates 

### DIFF
--- a/miri/datamodels/miri_reset_switch_charge_decay_model.py
+++ b/miri/datamodels/miri_reset_switch_charge_decay_model.py
@@ -30,6 +30,8 @@ https://jwst-pipeline.readthedocs.io/en/latest/jwst/datamodels/index.html
 26 Mar 2020: Ensure the model_type remains as originally defined when saving
              to a file.
 11 May 2020: Removed the CDP-6 version of the data model.
+24 Jul 2020: Remove the dependency on the actual structure of the data model,
+             since it changes frequently.
 
 @author: Steven Beard (UKATC)
 
@@ -66,42 +68,24 @@ class MiriResetSwitchChargeDecayModel(MiriDataModel):
         * Readable file object: Initialize from the given file object.
         * pyfits.HDUList: Initialize from the given pyfits.HDUList.
         
-    rscd_table. list of tuples or numpy record array (optional)
-        A list of tuples, or a numpy record array, where each record
-        contains the following information:
-        
-        * SUBARRAY: A string containing a subarray name. The string can
-          be 'GENERIC' to indicate that the decay factors do not
-          depend on the subarray.
-        * READPATT: A string containing a readout pattern. The string can
-          be 'ANY' to indicate that the decay factors do not
-          depend on the readout pattern.
-        * ONE: First decay constant (TBD).
-        * TWO: First decay constant (TBD).
-        * THREE: First decay constant (TBD).
-        * FOUR: First decay constant (TBD).
-
-        A rscd_table must either be defined in the initializer or in
-        this parameter. A blank table is not allowed.
-     detector: str (optional)
-        The name of the detector associated with this RSCD data.
     \*\*kwargs:
         All other keyword arguments are passed to the DataModel initialiser.
         See the jwst.datamodels documentation for the meaning of these keywords.
-        
+
     """
     schema_url = "miri_reset_switch_charge_decay.schema"
-    fieldnames = ('subarray', 'readpatt', 'rows', 'tau', 'ascale', 'pow',
-                  'illum_zp', 'illum_slope', 'illum2', 'param3',
-                  'crossopt', 'sat_zp', 'sat_slope', 'sat_2', 'sat_mzp',
-                  'sat_rowterm', 'sat_scale')
+    fieldnames_group = ('subarray', 'readpatt', 'group_skip')
+    fieldnames_gen = ('subarray', 'readpatt', 'lower_cuttoff', 'alpha_even', 'alpha_odd')
    
-    def __init__(self, init=None, rscd_table=None, detector=None, **kwargs):
+    def __init__(self, init=None, **kwargs):
         """
         
         Initialises the MiriResetSwitchChargeDecayModel class.
         
         Parameters: See class doc string.
+
+        NOTE: This data model changes sufficiently frequently that the MIRI
+        data model does not attempt to process it.
 
         """
         super(MiriResetSwitchChargeDecayModel, self).__init__(init=init, **kwargs)
@@ -113,27 +97,6 @@ class MiriResetSwitchChargeDecayModel(MiriDataModel):
         # This is a reference data model.
         self._reference_model()
         
-        # Define the detector identifier, if specified. (N.B. The detector
-        # ID is compulsory, so it must be specified either here, in the
-        # source file or later after creation of this data object.)
-        # The warning is commented out because it causes unnecessary
-        # output during tests or when creating an empty data product and
-        # filling it in later.
-        if detector is not None:
-            self.meta.instrument.detector = detector
-
-        if rscd_table is not None:
-            try:
-                self.rscd_table = rscd_table
-            except (ValueError, TypeError) as e:
-                strg = "rscd_table must be a numpy record array or list of records."
-                strg += "\n   %s" % str(e)
-                raise TypeError(strg)
-
-        # NOTE: The JWST schema does not define any units.
-#         # Copy the table column units from the schema, if defined.
-#         rscd_units = self.set_table_units('rscd_table')
-
     def _init_data_type(self):
         # Initialise the data model type
         model_type = get_my_model_type( self.__class__.__name__ )
@@ -154,34 +117,15 @@ if __name__ == '__main__':
     
     PLOTTING = False
     SAVE_FILES = False
-     
-    rscddata = [('FULL',          'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('FULL',          'FAST', 'EVEN', 1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('FULL',          'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('FULL',          'SLOW', 'EVEN', 1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASK1065',      'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASK1065',      'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASK1140',      'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASK1140',      'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASK1550',      'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASK1550',      'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASKLYOT',      'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASKLYOT',      'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('BRIGHTSKY',     'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('BRIGHTSKY',     'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('SLITLESSPRISM', 'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('SLITLESSPRISM', 'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ]
 
-    print("\nRSCD calibration with factors derived from list of tuples:")
-    with MiriResetSwitchChargeDecayModel( rscd_table=rscddata,
-                                          detector='MIRIFUSHORT' ) as testrscd1:
+    # Test an empty data model.
+    with MiriResetSwitchChargeDecayModel( ) as testrscd1:
         testrscd1.set_instrument_metadata(detector='MIRIFUSHORT',
                                           ccc_pos='OPEN',
                                           deck_temperature=11.0,
                                           detector_temperature=6.0)
         testrscd1.set_housekeeping_metadata('UK', author='MIRI team',
-                                           version='1.0', useafter='2015-11-20',
+                                           version='1.0', useafter='2020-05-20',
                                            description='Test data')
         print(testrscd1)
         if PLOTTING:

--- a/miri/datamodels/tests/test_reset_switch_charge_decay_model.py
+++ b/miri/datamodels/tests/test_reset_switch_charge_decay_model.py
@@ -71,7 +71,7 @@ class TestMiriResetSwitchChargeDecayModel(unittest.TestCase):
     def test_copy(self):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
-        self.assertIsNotNone(datacopy.rscd_table)
+#        self.assertIsNotNone(datacopy.rscd_table)
         # NOTE: Test that the contents are equal is removed.
         del datacopy
        

--- a/miri/datamodels/tests/test_reset_switch_charge_decay_model.py
+++ b/miri/datamodels/tests/test_reset_switch_charge_decay_model.py
@@ -84,7 +84,7 @@ class TestMiriResetSwitchChargeDecayModel(unittest.TestCase):
             # file and read back again without changing the data.
             self.dataproduct.save(self.testfile, overwrite=True)
             with MiriResetSwitchChargeDecayModel(self.testfile) as readback:
-                self.assertIsNotNone(readback.rscd_table)
+                self.assertIsNotNone(readback)
 #                self.assertEqual( len(self.dataproduct.rscd_table),
 #                                  len(readback.rscd_table) )
 #                original = np.asarray(self.dataproduct.rscd_table)

--- a/miri/datamodels/tests/test_reset_switch_charge_decay_model.py
+++ b/miri/datamodels/tests/test_reset_switch_charge_decay_model.py
@@ -12,6 +12,8 @@ in the datamodels.miri_reset_switch_charge_decay_model module.
 15 Jun 2017: Do not set observation metadata. It isn't
              appropriate for a reference file.
 12 Jul 2017: Replaced "clobber" parameter with "overwrite".
+24 Jul 2020: Reduced the number of tests to remove the dependency on the actual
+             structure of the data model, since it changes frequently.
 
 @author: Steven Beard (UKATC)
 
@@ -32,37 +34,13 @@ class TestMiriResetSwitchChargeDecayModel(unittest.TestCase):
     # Test the MiriResetSwitchChargeDecayModel class.
     
     def setUp(self):
-        # Create a typical rscd product.
-        self.rscddata = [('FULL',          'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('FULL',          'FAST', 'EVEN', 1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('FULL',          'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('FULL',          'SLOW', 'EVEN', 1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASK1065',      'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASK1065',      'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASK1140',      'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASK1140',      'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASK1550',      'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASK1550',      'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASKLYOT',      'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('MASKLYOT',      'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('BRIGHTSKY',     'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('BRIGHTSKY',     'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('SLITLESSPRISM', 'FAST', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ('SLITLESSPRISM', 'SLOW', 'ODD',  1.0e-1,  2.0e-2, 3.0e-3, 4.0e-4, 5.0e-5, 6.0e-6, 7.0e-7, 8.0e-8, 9.0e-9, 10.0e-2, 11.0e-4, 12.0e-6, 13.0e-8, 14.0),
-                ]
-        self.dataproduct = MiriResetSwitchChargeDecayModel( rscd_table=self.rscddata,
-                                                            detector='MIRIMAGE' )
-        # Add some example metadata.
-        self.dataproduct.set_instrument_metadata(detector='MIRIMAGE',
-                                                 ccc_pos='CLOSED',
-                                                 deck_temperature=11.0,
-                                                 detector_temperature=6.0)
+        # Create a minimal data product.
+        self.dataproduct = MiriResetSwitchChargeDecayModel( )
         self.testfile = "MiriResetSwitchChargeDecayModel_test.fits"
         
     def tearDown(self):
         # Tidy up
         del self.dataproduct
-        # TBD
         # Remove temporary file, if able to.
         if os.path.isfile(self.testfile):
             try:
@@ -83,33 +61,18 @@ class TestMiriResetSwitchChargeDecayModel(unittest.TestCase):
         self.assertIsNotNone(pedigree)
 
     def test_creation(self):
-        # Check that the field names in the class variable are the same
-        # as the ones declared in the schema.
-        class_names = list(MiriResetSwitchChargeDecayModel.fieldnames)
-        schema_names = list(self.dataproduct.get_field_names('rscd_table'))
-        self.assertEqual(class_names, schema_names,
-                         "'fieldnames' class variable does not match schema")
-
         # It must be possible to create an empty data product and fill
         # in its contents later.
         nulldp = MiriResetSwitchChargeDecayModel( )
         descr1 = str(nulldp)
         self.assertIsNotNone(descr1)
-        nulldp.rscd_table = self.rscddata
-        self.assertIsNotNone(nulldp.rscd_table)
-        descr2 = str(nulldp)
-        self.assertIsNotNone(descr2)
-        del nulldp, descr1, descr2    
+        del nulldp, descr1
 
     def test_copy(self):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy.rscd_table)
-        self.assertEqual( len(self.dataproduct.rscd_table),
-                          len(datacopy.rscd_table) )
-        table1 = np.asarray(self.dataproduct.rscd_table)
-        table2 = np.asarray(datacopy.rscd_table)
-        assert_recarray_equal(table1, table2)
+        # NOTE: Test that the contents are equal is removed.
         del datacopy
        
     def test_fitsio(self):
@@ -122,11 +85,11 @@ class TestMiriResetSwitchChargeDecayModel(unittest.TestCase):
             self.dataproduct.save(self.testfile, overwrite=True)
             with MiriResetSwitchChargeDecayModel(self.testfile) as readback:
                 self.assertIsNotNone(readback.rscd_table)
-                self.assertEqual( len(self.dataproduct.rscd_table),
-                                  len(readback.rscd_table) )
-                original = np.asarray(self.dataproduct.rscd_table)
-                duplicate = np.asarray(readback.rscd_table)
-                assert_recarray_equal(original, duplicate)
+#                self.assertEqual( len(self.dataproduct.rscd_table),
+#                                  len(readback.rscd_table) )
+#                original = np.asarray(self.dataproduct.rscd_table)
+#                duplicate = np.asarray(readback.rscd_table)
+#                assert_recarray_equal(original, duplicate)
                 del readback
         
     def test_description(self):


### PR DESCRIPTION
This PR introduces changes needed to make MiriTE compatible with JWST PL B7.5.

The changes include:
- Reduce RSCD test to minimum to make the MIRI data models more resilient to changes.