### PR TITLE
MIRI-944: jwst.datamodels debug message workaround

### DIFF
--- a/miri/datamodels/__init__.py
+++ b/miri/datamodels/__init__.py
@@ -175,7 +175,7 @@ data/example_filter.fits, example_measurements.fits:
 05 Jan 2018: More version control information added. SVN info dropped.
 15 Nov 2018: Documentation update.
 07 Dec 2020: Add workaround to suppress debug messages from jwst.datamodels
-             in Pipeline build 7.6.
+             in Pipeline build 7.6. Print warning if newer build is detected.
 """
 
 __project__ = 'MIRI Data Model Software'
@@ -191,6 +191,11 @@ try:
     import jwst.datamodels
     jwst.datamodels.util.log.setLevel(logging.INFO)
     jwst.datamodels.fits_support.log.setLevel(logging.INFO)
+
+    # Warn if newer JWST PL build is detected
+    if jwst.__version__ > '0.17.1':
+        print("Warning: miri package found version of 'jwst' newer than 0.17.1 (build 7.6); please remove workaround"
+              "for MIRI-944.")
 except Exception:
     pass
 # MIRI-944: end of workaround.

--- a/miri/datamodels/__init__.py
+++ b/miri/datamodels/__init__.py
@@ -174,13 +174,26 @@ data/example_filter.fits, example_measurements.fits:
 29 Jun 2017: Updated to use build 7.1 data models.
 05 Jan 2018: More version control information added. SVN info dropped.
 15 Nov 2018: Documentation update.
-
+07 Dec 2020: Add workaround to suppress debug messages from jwst.datamodels
+             in Pipeline build 7.6.
 """
 
 __project__ = 'MIRI Data Model Software'
 __author__ = 'MIRI Software Team'
 __maintainer__ = 'MIRI Software Team: mirisim@roe.ac.uk'
 __copyright__ = '2020, %s' % __author__
+
+# MIRI-944: temporary workaround to avoid debug-level log messages from the
+# 'jwst.datamodels' package in Pipeline build 7.6. This workaround should be
+# removed once MIRICLE migrates to build 7.7 or newer.
+try:
+    import logging
+    import jwst.datamodels
+    jwst.datamodels.util.log.setLevel(logging.INFO)
+    jwst.datamodels.fits_support.log.setLevel(logging.INFO)
+except Exception:
+    pass
+# MIRI-944: end of workaround.
 
 # Import common data products
 from miri.datamodels.miri_model_base import MiriDataModel


### PR DESCRIPTION
MIRI-944 is about migrating MIRICLE to JWST Pipeline build 7.6.

It was noted that in build 7.6, there are two modules within jwst.datamodels that, perhaps inadvertently, have had their log level forcibly set to "debug". As a result, when running "miri" against "jwst" build 7.6, one will see a series of DEBUG log messages show up any time that miri.datamodels creates a datamodel instance (e.g. when opening a CDP). The warning messages do not appear crucial (see discussion in MIRI-944: https://ukatcfaultlog.atlassian.net/browse/MIRI-944), and from build 7.7, the log level in those jwst.datamodels modules was set back to normal.

This PR introduces a temporary workaround in miri.datamodels.__init__.py, to override the debug level in the 2 affected modules of jwst.datamodels, thereby suppressing the messages. Since virtually all of our datamodel access in MIRICLE goes through miri.datamodels, this workaround should cover our typical use-cases. The workaround could be removed again once we migrate to build 7.7.

I've wrapped the workaround in a try/except to ensure that it cannot accidentally prevent import of "miri" in earlier MIRICLE versions (e.g. against pipeline build 7.5).

Please let me know if you have any comments/questions about this approach.