### PR TITLE
remove explicit array length numbers in LRS schemas

### DIFF
--- a/miri/datamodels/schemas/miri_aperture_correction_lrs.schema.yaml
+++ b/miri/datamodels/schemas/miri_aperture_correction_lrs.schema.yaml
@@ -76,19 +76,19 @@ allOf:
         datatype: [ascii, 15]
       - name: wavelength
         datatype: float32
-        shape: [388]
+        ndim: 1
         unit: micron
       - name: nelem_wl
         datatype: uint16
       - name: size
         datatype: uint8
-        shape: [40]
+        ndim: 1
         unit: pixels
       - name: nelem_size
         datatype: uint8
       - name: apcorr
         datatype: float32
-        shape: [388, 40]
+        ndim: 2
       - name: apcorr_err
         datatype: float32
-        shape: [388, 40]
+        ndim: 2

--- a/miri/datamodels/schemas/miri_position_correction_lrs.schema.yaml
+++ b/miri/datamodels/schemas/miri_position_correction_lrs.schema.yaml
@@ -34,4 +34,4 @@ allOf:
         unit: micron
       - name: pos_corr
         datatype: float32
-        shape: [81]
+        ndim: 1


### PR DESCRIPTION
This branch just replaced the shape keyword from the yaml schema of LRS aperture correction data models with the ndim keyword to have a flexible array size.