### PR TITLE
MIRI-949: integrate changes needed for "jwst' B7.7.1

### DIFF
--- a/miri/__init__.py
+++ b/miri/__init__.py
@@ -53,5 +53,5 @@ miri.simulators
 __project__ = 'MIRI Tool and Environment Software'
 __author__ = 'MIRI Software Team'
 __maintainer__ = 'MIRI Software Team: mirisim@roe.ac.uk'
-__copyright__ = '2020, %s' % __author__
+__copyright__ = '2021, %s' % __author__
 __version__ = '7.4'

--- a/miri/datamodels/__init__.py
+++ b/miri/datamodels/__init__.py
@@ -176,6 +176,8 @@ data/example_filter.fits, example_measurements.fits:
 15 Nov 2018: Documentation update.
 07 Dec 2020: Add workaround to suppress debug messages from jwst.datamodels
              in Pipeline build 7.6. Print warning if newer build is detected.
+02 Mar 2021: Update workaround to suppress debug level messages from
+             stdatamodels package in Pipeline build 7.7.
 """
 
 __project__ = 'MIRI Data Model Software'
@@ -183,22 +185,16 @@ __author__ = 'MIRI Software Team'
 __maintainer__ = 'MIRI Software Team: mirisim@roe.ac.uk'
 __copyright__ = '2020, %s' % __author__
 
-# MIRI-944: temporary workaround to avoid debug-level log messages from the
-# 'jwst.datamodels' package in Pipeline build 7.6. This workaround should be
-# removed once MIRICLE migrates to build 7.7 or newer.
+# MIRI-949: temporary workaround to avoid debug-level log messages from the
+# 'stdatamodels' package in Pipeline build 7.7. This workaround should be
+# removed as soon as possible with newer Pipeline builds.
 try:
     import logging
-    import jwst.datamodels
-    jwst.datamodels.util.log.setLevel(logging.INFO)
-    jwst.datamodels.fits_support.log.setLevel(logging.INFO)
-
-    # Warn if newer JWST PL build is detected
-    if jwst.__version__ > '0.17.1':
-        print("Warning: miri package found version of 'jwst' newer than 0.17.1 (build 7.6); please remove workaround"
-              "for MIRI-944.")
+    import stdatamodels
+    stdatamodels.fits_support.log.setLevel(logging.INFO)
 except Exception:
     pass
-# MIRI-944: end of workaround.
+# MIRI-949: end of workaround.
 
 # Import common data products
 from miri.datamodels.miri_model_base import MiriDataModel

--- a/miri/datamodels/__init__.py
+++ b/miri/datamodels/__init__.py
@@ -183,7 +183,7 @@ data/example_filter.fits, example_measurements.fits:
 __project__ = 'MIRI Data Model Software'
 __author__ = 'MIRI Software Team'
 __maintainer__ = 'MIRI Software Team: mirisim@roe.ac.uk'
-__copyright__ = '2020, %s' % __author__
+__copyright__ = '2021, %s' % __author__
 
 # MIRI-949: temporary workaround to avoid debug-level log messages from the
 # 'stdatamodels' package in Pipeline build 7.7. This workaround should be

--- a/miri/datamodels/compatibility.py
+++ b/miri/datamodels/compatibility.py
@@ -22,6 +22,7 @@ old MIRI data model and the new one. The module serves two purposes:
 06 Feb 2013: Most of the contents moved to MiriDataModel.
 09 Jul 2014: field_def changed to dq_def.
 09 Sep 2015: Brought up to date with changes to the dq_def table.
+02 Dec 2020: Removed unused jwst imports.
 
 @author: Steven Beard (UKATC)
 
@@ -31,10 +32,6 @@ import sys, os
 
 import numpy as np
 import numpy.ma as ma
-
-# Import the STScI image model and utilities
-import jwst.datamodels.util as jmutil
-from jwst.datamodels.model_base import DataModel
 
 from miri.datamodels.dqflags import insert_value_column
 

--- a/miri/datamodels/miri_fluxconversion_models.py
+++ b/miri/datamodels/miri_fluxconversion_models.py
@@ -93,6 +93,7 @@ https://jwst-pipeline.readthedocs.io/en/latest/jwst/datamodels/index.html
              is also changed from "arcsec^2" to "steradian".
 26 Mar 2020: Ensure the model_type remains as originally defined when saving
              to a file.
+02 Dec 2020: Update import of jwst base model class to JwstDataModel.
 
 @author: Steven Beard (UKATC), Vincent Geers (DIAS)
 
@@ -106,7 +107,7 @@ LOGGER = logging.getLogger("miri.datamodels") # Get a logger
 import numpy as np
 
 # Import the MIRI base data model and utilities.
-from jwst.datamodels.model_base import DataModel
+from jwst.datamodels import JwstDataModel
 from miri.datamodels.ancestry import get_my_model_type
 from miri.datamodels.dqflags import insert_value_column
 from miri.datamodels.miri_model_base import MiriDataModel
@@ -120,7 +121,7 @@ __all__ = ['MiriFluxconversionModel', \
            'MiriLrsFluxconversionModel', \
            'MiriMrsFluxconversionModel']
 
-# class FluxModel(DataModel):
+# class FluxModel(JwstDataModel):
 #     """
 #     
 #     A data model for a trivial flux table. Used for testing.
@@ -145,7 +146,7 @@ class MiriFluxconversionModel(MiriDataModel):
     """
     
     A generic data model for a MIRI flux conversion table, based on the STScI
-    base model, DataModel.
+    base model, JwstDataModel.
     
     :Parameters:
     
@@ -169,7 +170,7 @@ class MiriFluxconversionModel(MiriDataModel):
         A flux table must either be defined in the initializer or in
         this parameter. A blank table is not allowed.
     \*\*kwargs:
-        All other keyword arguments are passed to the DataModel initialiser.
+        All other keyword arguments are passed to the JwstDataModel initialiser.
         See the jwst.datamodels documentation for the meaning of these keywords.
         
     """

--- a/miri/datamodels/miri_model_base.py
+++ b/miri/datamodels/miri_model_base.py
@@ -185,6 +185,9 @@ https://jwst-pipeline.readthedocs.io/en/latest/jwst/datamodels/index.html
 13 Dec 2019: Modified copy_metadata to prevent DATAMODL, FILETYPE, FILENAME
              and REFTYPE keywords being copied.
 10 Feb 2020: Corrected typo in the list_data_arrays function.
+02 Dec 2020: Update jwst imports that have moved to the stdatamodels package.
+             Remove work-around for the 'SIMPLE' and 'EXTEND' FITS keywords,
+             which are handled correctly by stdatamodels.
 
 @author: Steven Beard (UKATC), Vincent Geers (UKATC)
 
@@ -203,9 +206,9 @@ from asdf.tags.core import HistoryEntry
 from  asdf import AsdfFile
 from asdf import schema as asdf_schema
 # Import the STScI base data model and utilities
-import jwst.datamodels.fits_support as mfits
-import jwst.datamodels.schema as mschema
-from jwst.datamodels.model_base import DataModel
+import stdatamodels.fits_support as mfits
+import stdatamodels.schema as mschema
+from jwst.datamodels import JwstDataModel
 
 # Import the MIRI data models and the data model plotter.
 import miri.datamodels
@@ -384,11 +387,11 @@ def _shape_to_string(shape, axes=None):
     return strg
 
 
-class MiriDataModel(DataModel):
+class MiriDataModel(JwstDataModel):
     """
 
     A base data model for MIRI data, with MIRI-specific utilities and
-    add-ons, based on the STScI base model, DataModel. The MiriDataModel
+    add-ons, based on the STScI base model, JwstDataModel. The MiriDataModel
     also includes MIRI-specific additions to the metadata.
 
     :Parameters:
@@ -408,7 +411,7 @@ class MiriDataModel(DataModel):
         An additional descriptive title for the data structure (if the
         default title contained in the schema is too vague).
     \*\*kwargs:
-        All other keyword arguments are passed to the DataModel initialiser.
+        All other keyword arguments are passed to the JwstDataModel initialiser.
         See the jwst.datamodels documentation for the meaning of these keywords.
 
     """
@@ -2079,10 +2082,7 @@ class MiriDataModel(DataModel):
                 return
             if not include_history and keyw == 'HISTORY':
                 return
-            if not include_builtin and mfits._is_builtin_fits_keyword(keyw):
-                return
-            # Work around bug in mfits
-            if not include_builtin and (keyw == 'SIMPLE' or keyw == 'EXTEND'):
+            if not include_builtin and mfits.is_builtin_fits_keyword(keyw):
                 return
             comment = subschema.get('title')
             kw = '.'.join(path)
@@ -2155,10 +2155,7 @@ class MiriDataModel(DataModel):
                 return
             if not include_history and keyw == 'HISTORY':
                 return
-            if not include_builtin and mfits._is_builtin_fits_keyword(keyw):
-                return
-            # Work around bug in mfits
-            if not include_builtin and (keyw == 'SIMPLE' or keyw == 'EXTEND'):
+            if not include_builtin and mfits.is_builtin_fits_keyword(keyw):
                 return
             kw = '.'.join(path)
             if not include_undefined and self[kw] is None:

--- a/miri/datamodels/operations.py
+++ b/miri/datamodels/operations.py
@@ -36,6 +36,7 @@ https://jwst-pipeline.readthedocs.io/en/latest/jwst/datamodels/index.html
 27 Jun 2018: Added HasDataErrAndGroups class to be used with ramp data.
 12 Mar 2019: Removed use of astropy.extern.six (since Python 2 no longer used).
 12 Feb 2020: Added _check_broadcastable() methods.
+02 Dec 2020: Update import of jwst base model class to JwstDataModel.
 
 @author: Steven Beard (UKATC), Vincent Geers (UKATC)
 
@@ -49,7 +50,7 @@ from miri.datamodels.dqflags import master_flags, combine_quality
 
 # Import the STScI image model and utilities
 import jwst.datamodels.util as jmutil
-from jwst.datamodels.model_base import DataModel
+from jwst.datamodels import JwstDataModel
 
 # List all classes and global functions here.
 __all__ = ['are_broadcastable', 'HasMask', 'HasData', 'HasDataErrAndDq']
@@ -186,7 +187,7 @@ class HasMask(object):
             # work provided the two arrays are broadcastable.
             newobject.dq = self.dq | np.asarray(other, dtype=self.dq.dtype)
 
-        elif isinstance(other, DataModel) and hasattr(other, 'dq'):
+        elif isinstance(other, JwstDataModel) and hasattr(other, 'dq'):
             # Two mask data products are being combined together.
             newobject.dq = self.dq | other.dq
 
@@ -223,7 +224,7 @@ class HasMask(object):
             # work provided the two arrays are broadcastable.
             newobject.dq = self.dq ^ np.asarray(other, dtype=self.dq.dtype)
 
-        elif isinstance(other, DataModel) and \
+        elif isinstance(other, JwstDataModel) and \
              hasattr(other, 'dq') and self._isvalid(other.dq):
             # Two mask data products are being combined together.
             newobject.dq = self.dq ^ other.dq
@@ -261,7 +262,7 @@ class HasMask(object):
             # work provided the two arrays are broadcastable.
             newobject.dq = self.dq & np.asarray(other, dtype=self.dq.dtype)
 
-        elif isinstance(other, DataModel) and \
+        elif isinstance(other, JwstDataModel) and \
              hasattr(other, 'dq') and self._isvalid(other.dq):
             # Two mask data products are being combined together.
             newobject.dq = self.dq & other.dq
@@ -358,7 +359,7 @@ class HasData(object):
             # work provided the two arrays are broadcastable.
             newobject.data = self.data + np.asarray(other)
             
-        elif isinstance(other, DataModel):
+        elif isinstance(other, JwstDataModel):
             # Two data products are being added together. Ensure they
             # both have a valid primary data array.
             if hasattr(other, 'data') and self._isvalid(other.data):
@@ -397,7 +398,7 @@ class HasData(object):
             # work provided the two arrays are broadcastable.
             newobject.data = self.data - np.asarray(other)
             
-        elif isinstance(other, DataModel):
+        elif isinstance(other, JwstDataModel):
             # Two data products are being subtracted together. Ensure they
             # both have a valid primary data array.
             if hasattr(other, 'data') and self._isvalid(other.data):
@@ -436,7 +437,7 @@ class HasData(object):
             # work provided the two arrays are broadcastable.
             newobject.data = self.data * np.asarray(other)
             
-        elif isinstance(other, DataModel):
+        elif isinstance(other, JwstDataModel):
             # Two data products are being multiplied together. Ensure they
             # both have a valid primary data array.
             if hasattr(other, 'data') and self._isvalid(other.data):
@@ -480,7 +481,7 @@ class HasData(object):
             # NOTE: Any divide by zero operations will be trapped by numpy.
             newobject.data = self.data / np.asarray(other)
             
-        elif isinstance(other, DataModel):
+        elif isinstance(other, JwstDataModel):
             # The data product is being divided by another. Ensure they
             # both have a valid primary data array.
             # NOTE: Any divide by zero operations will be trapped by numpy.
@@ -927,7 +928,7 @@ class HasDataErrAndDq(HasData):
     def __add__(self, other):
         """
         
-        Add a scalar, an array or another DataModel object to
+        Add a scalar, an array or another JwstDataModel object to
         this MiriMeasuredModel object.
         
         """
@@ -955,7 +956,7 @@ class HasDataErrAndDq(HasData):
                 newobject.err = np.zeros_like(self.err)
             newobject.dq = self.dq
              
-        elif isinstance(other, DataModel):
+        elif isinstance(other, JwstDataModel):
             # Two data products are being added together. Ensure they
             # both have a valid primary data array.
             if hasattr(other, 'data') and self._isvalid(other.data):
@@ -986,7 +987,7 @@ class HasDataErrAndDq(HasData):
     def __sub__(self, other):
         """
         
-        Subtract a scalar, an array or another DataModel object from
+        Subtract a scalar, an array or another JwstDataModel object from
         this MiriMeasuredModel object.
         
         """  
@@ -1014,7 +1015,7 @@ class HasDataErrAndDq(HasData):
                 newobject.err = np.zeros_like(self.err)
             newobject.dq = self.dq
             
-        elif isinstance(other, DataModel):
+        elif isinstance(other, JwstDataModel):
             # Two data products are being subtracted. Ensure they
             # both have a valid primary data array.
             if hasattr(other, 'data') and self._isvalid(other.data):
@@ -1045,7 +1046,7 @@ class HasDataErrAndDq(HasData):
         """
         
         Multiply this MiriMeasuredModel object by a scalar, an array or
-        another DataModel object.
+        another JwstDataModel object.
         
         """  
         # Check this object is capable of mathematical operation.
@@ -1072,7 +1073,7 @@ class HasDataErrAndDq(HasData):
                 newobject.err = np.zeros_like(self.err)
             newobject.dq = self.dq
             
-        elif isinstance(other, DataModel):
+        elif isinstance(other, JwstDataModel):
             # Two data products are being multiplied together. Ensure they
             # both have a valid primary data array.
             if hasattr(other, 'data') and self._isvalid(other.data):
@@ -1104,7 +1105,7 @@ class HasDataErrAndDq(HasData):
         """
         
         Divide this MiriMeasuredModel object by a scalar, an array or
-        another DataModel object.
+        another JwstDataModel object.
         
         """  
         # Check this object is capable of mathematical operation.
@@ -1137,7 +1138,7 @@ class HasDataErrAndDq(HasData):
                 newobject.err = np.zeros_like(self.err)
             newobject.dq = self.dq
             
-        elif isinstance(other, DataModel):
+        elif isinstance(other, JwstDataModel):
             # The data product is being divided by another. Ensure they
             # both have a valid primary data array.
             # NOTE: Any divide by zero operations will be trapped by numpy.
@@ -1244,7 +1245,7 @@ class HasDataErrAndGroups(HasDataErrAndDq):
     def __add__(self, other):
         """
         
-        Add a scalar, an array or another DataModel object to
+        Add a scalar, an array or another JwstDataModel object to
         this MiriMeasuredModel object.
         
         """
@@ -1274,7 +1275,7 @@ class HasDataErrAndGroups(HasDataErrAndDq):
             newobject.pixeldq = self.pixeldq
             newobject.groupdq = self.groupdq
              
-        elif isinstance(other, DataModel):
+        elif isinstance(other, JwstDataModel):
             # Two data products are being added together. Ensure they
             # both have a valid primary data array.
             if hasattr(other, 'data') and self._isvalid(other.data):
@@ -1307,7 +1308,7 @@ class HasDataErrAndGroups(HasDataErrAndDq):
     def __sub__(self, other):
         """
         
-        Subtract a scalar, an array or another DataModel object from
+        Subtract a scalar, an array or another JwstDataModel object from
         this MiriMeasuredModel object.
         
         """  
@@ -1337,7 +1338,7 @@ class HasDataErrAndGroups(HasDataErrAndDq):
             newobject.pixeldq = self.pixeldq
             newobject.groupdq = self.groupdq
             
-        elif isinstance(other, DataModel):
+        elif isinstance(other, JwstDataModel):
             # Two data products are being subtracted. Ensure they
             # both have a valid primary data array.
             if hasattr(other, 'data') and self._isvalid(other.data):
@@ -1370,7 +1371,7 @@ class HasDataErrAndGroups(HasDataErrAndDq):
         """
         
         Multiply this MiriMeasuredModel object by a scalar, an array or
-        another DataModel object.
+        another JwstDataModel object.
         
         """  
         # Check this object is capable of mathematical operation.
@@ -1399,7 +1400,7 @@ class HasDataErrAndGroups(HasDataErrAndDq):
             newobject.pixeldq = self.pixeldq
             newobject.groupdq = self.groupdq
             
-        elif isinstance(other, DataModel):
+        elif isinstance(other, JwstDataModel):
             # Two data products are being multiplied together. Ensure they
             # both have a valid primary data array.
             if hasattr(other, 'data') and self._isvalid(other.data):
@@ -1433,7 +1434,7 @@ class HasDataErrAndGroups(HasDataErrAndDq):
         """
         
         Divide this MiriMeasuredModel object by a scalar, an array or
-        another DataModel object.
+        another JwstDataModel object.
         
         """  
         # Check this object is capable of mathematical operation.
@@ -1468,7 +1469,7 @@ class HasDataErrAndGroups(HasDataErrAndDq):
             newobject.pixeldq = self.pixeldq
             newobject.groupdq = self.groupdq
             
-        elif isinstance(other, DataModel):
+        elif isinstance(other, JwstDataModel):
             # The data product is being divided by another. Ensure they
             # both have a valid primary data array.
             # NOTE: Any divide by zero operations will be trapped by numpy.

--- a/miri/simulators/__init__.py
+++ b/miri/simulators/__init__.py
@@ -53,7 +53,7 @@ data/detector/*.fits
 __project__ = 'MIRI Simulators'
 __author__ = 'MIRI Software Team'
 __maintainer__ = 'MIRI Software Team: mirisim@roe.ac.uk'
-__copyright__ = '2020, %s' % __author__
+__copyright__ = '2021, %s' % __author__
 
 # Import classes that need to be accessible from the miri.simulators level.
 from miri.simulators.integrators import PoissonIntegrator, ImperfectIntegrator

--- a/miri/simulators/scasim/__init__.py
+++ b/miri/simulators/scasim/__init__.py
@@ -68,4 +68,4 @@ data/SCATestInput80x64.fits
 __project__ = 'MIRI SCA Simulator'
 __author__ = 'MIRI Software Team'
 __maintainer__ = 'MIRI Software Team: mirisim@roe.ac.uk'
-__copyright__ = '2020, %s' % __author__
+__copyright__ = '2021, %s' % __author__

--- a/miri/tools/__init__.py
+++ b/miri/tools/__init__.py
@@ -53,4 +53,4 @@ Data
 __project__ = 'MIRI Tools Software'
 __author__ = 'MIRI Software Team'
 __maintainer__ = 'MIRI Software Team: mirisim@roe.ac.uk'
-__copyright__ = '2020, %s' % __author__
+__copyright__ = '2021, %s' % __author__

--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ setup(
     entry_points=entry_points,
     install_requires=[
         'Cython>=0.29.15',
-        'jwst>=0.15.0',
+        'jwst>=0.18.0',
         'matplotlib>=3.1.0',
         'numpy>=1.18.1',
         'parameterized>=0.7.0',


### PR DESCRIPTION
This PR is to discuss and make changes needed to be compatible with JWST Pipeline build 7.7.1.

It includes the changes needed due to the migration of jwst.datamodels to stdatamodels, as contributed by Edward Slavich.