### PR TITLE
MIR-884 - FRINGEFREQ CDP update

### DIFF
--- a/miri/datamodels/miri_fringe_frequencies_model.py
+++ b/miri/datamodels/miri_fringe_frequencies_model.py
@@ -80,7 +80,7 @@ class MiriMrsFringeFrequenciesModel(MiriDataModel):
         
     """
     schema_url = "miri_fringe_frequencies_mrs.schema"
-    fieldnames = ('slice', 'ffreq', 'dffreq', 'min_nfringes', 'max_nfringes', 'min_snr', 'pgram_res')
+    fieldnames = ('Slice', 'ffreq', 'dffreq', 'min_nfringes', 'max_nfringes', 'min_snr', 'pgram_res')
     
     def __init__(self, init=None, fringefreq_table=None, **kwargs):
         """

--- a/miri/datamodels/miri_fringe_frequencies_model.py
+++ b/miri/datamodels/miri_fringe_frequencies_model.py
@@ -80,7 +80,7 @@ class MiriMrsFringeFrequenciesModel(MiriDataModel):
         
     """
     schema_url = "miri_fringe_frequencies_mrs.schema"
-    fieldnames = ('Slice', 'ffreq', 'dffreq', 'min_nfringes', 'max_nfringes', 'min_snr', 'pgram_res')
+    fieldnames = ('slice', 'ffreq', 'dffreq', 'min_nfringes', 'max_nfringes', 'min_snr', 'pgram_res')
     
     def __init__(self, init=None, fringefreq_table=None, **kwargs):
         """
@@ -112,6 +112,9 @@ class MiriMrsFringeFrequenciesModel(MiriDataModel):
          
         # Copy the table column units from the schema, if defined.
         _ = self.set_table_units('fringefreq_table_short')
+        _ = self.set_table_units('fringefreq_table_medium')
+        _ = self.set_table_units('fringefreq_table_long')
+        _ = self.set_table_units('max_amp')
 
     def _init_data_type(self):
         # Initialise the data model type

--- a/miri/datamodels/schemas/miri_fringe_frequencies_mrs.schema.yaml
+++ b/miri/datamodels/schemas/miri_fringe_frequencies_mrs.schema.yaml
@@ -164,7 +164,7 @@ allOf:
       title: Fringe frequencies table for SHORT
       fits_hdu: RFC_FREQ_SHORT
       datatype:
-      - name: slice
+      - name: Slice
         datatype: float64
       - name: ffreq
         datatype: float64
@@ -182,7 +182,7 @@ allOf:
       title: Fringe frequencies table for MEDIUM
       fits_hdu: RFC_FREQ_MEDIUM
       datatype:
-      - name: slice
+      - name: Slice
         datatype: float64
       - name: ffreq
         datatype: float64
@@ -200,7 +200,7 @@ allOf:
       title: Fringe frequencies table for LONG
       fits_hdu: RFC_FREQ_LONG
       datatype:
-      - name: slice
+      - name: Slice
         datatype: float64
       - name: ffreq
         datatype: float64

--- a/miri/datamodels/schemas/miri_fringe_frequencies_mrs.schema.yaml
+++ b/miri/datamodels/schemas/miri_fringe_frequencies_mrs.schema.yaml
@@ -164,7 +164,7 @@ allOf:
       title: Fringe frequencies table for SHORT
       fits_hdu: RFC_FREQ_SHORT
       datatype:
-      - name: Slice
+      - name: slice
         datatype: float64
       - name: ffreq
         datatype: float64
@@ -182,7 +182,7 @@ allOf:
       title: Fringe frequencies table for MEDIUM
       fits_hdu: RFC_FREQ_MEDIUM
       datatype:
-      - name: Slice
+      - name: slice
         datatype: float64
       - name: ffreq
         datatype: float64
@@ -200,7 +200,7 @@ allOf:
       title: Fringe frequencies table for LONG
       fits_hdu: RFC_FREQ_LONG
       datatype:
-      - name: Slice
+      - name: slice
         datatype: float64
       - name: ffreq
         datatype: float64

--- a/miri/datamodels/schemas/miri_fringe_frequencies_mrs.schema.yaml
+++ b/miri/datamodels/schemas/miri_fringe_frequencies_mrs.schema.yaml
@@ -6,7 +6,7 @@ allOf:
     meta:
       type: object
       properties:
-        fringefreq_table:
+        fringefreq_table_short:
           type: object
           title: Information about the fringe frequencies table
           properties:
@@ -14,35 +14,212 @@ allOf:
               type: string
               title: Column 1 units
               default: ''
-              fits_hdu: FRINGE_FREQ
+              fits_hdu: RFC_FREQ_SHORT
               fits_keyword: TUNIT1
             tunit2:
               type: string
               title: Column 2 units
               default: cm^-1
-              fits_hdu: FRINGE_FREQ
+              fits_hdu: RFC_FREQ_SHORT
               fits_keyword: TUNIT2
             tunit3:
               type: string
               title: Column 3 units
               default: cm^-1
-              fits_hdu: FRINGE_FREQ
+              fits_hdu: RFC_FREQ_SHORT
               fits_keyword: TUNIT3
             tunit4:
               type: string
               title: Column 4 units
               default: ''
-              fits_hdu: FRINGE_FREQ
+              fits_hdu: RFC_FREQ_SHORT
               fits_keyword: TUNIT4
-    fringefreq_table:
-      title: Fringe frequencies table
-      fits_hdu: FRINGE_FREQ
+            tunit5:
+              type: string
+              title: Column 5 units
+              default: ''
+              fits_hdu: RFC_FREQ_SHORT
+              fits_keyword: TUNIT5
+            tunit6:
+              type: string
+              title: Column 6 units
+              default: ''
+              fits_hdu: RFC_FREQ_SHORT
+              fits_keyword: TUNIT6
+            tunit7:
+              type: string
+              title: Column 7 units
+              default: cm^-1
+              fits_hdu: RFC_FREQ_SHORT
+              fits_keyword: TUNIT7
+        fringefreq_table_medium:
+          type: object
+          title: Information about the fringe frequencies table
+          properties:
+            tunit1:
+              type: string
+              title: Column 1 units
+              default: ''
+              fits_hdu: RFC_FREQ_MEDIUM
+              fits_keyword: TUNIT1
+            tunit2:
+              type: string
+              title: Column 2 units
+              default: cm^-1
+              fits_hdu: RFC_FREQ_MEDIUM
+              fits_keyword: TUNIT2
+            tunit3:
+              type: string
+              title: Column 3 units
+              default: cm^-1
+              fits_hdu: RFC_FREQ_MEDIUM
+              fits_keyword: TUNIT3
+            tunit4:
+              type: string
+              title: Column 4 units
+              default: ''
+              fits_hdu: RFC_FREQ_MEDIUM
+              fits_keyword: TUNIT4
+            tunit5:
+              type: string
+              title: Column 5 units
+              default: ''
+              fits_hdu: RFC_FREQ_MEDIUM
+              fits_keyword: TUNIT5
+            tunit6:
+              type: string
+              title: Column 6 units
+              default: ''
+              fits_hdu: RFC_FREQ_MEDIUM
+              fits_keyword: TUNIT6
+            tunit7:
+              type: string
+              title: Column 7 units
+              default: cm^-1
+              fits_hdu: RFC_FREQ_MEDIUM
+              fits_keyword: TUNIT7
+        fringefreq_table_long:
+          type: object
+          title: Information about the fringe frequencies table
+          properties:
+            tunit1:
+              type: string
+              title: Column 1 units
+              default: ''
+              fits_hdu: RFC_FREQ_LONG
+              fits_keyword: TUNIT1
+            tunit2:
+              type: string
+              title: Column 2 units
+              default: cm^-1
+              fits_hdu: RFC_FREQ_LONG
+              fits_keyword: TUNIT2
+            tunit3:
+              type: string
+              title: Column 3 units
+              default: cm^-1
+              fits_hdu: RFC_FREQ_LONG
+              fits_keyword: TUNIT3
+            tunit4:
+              type: string
+              title: Column 4 units
+              default: ''
+              fits_hdu: RFC_FREQ_LONG
+              fits_keyword: TUNIT4
+            tunit5:
+              type: string
+              title: Column 5 units
+              default: ''
+              fits_hdu: RFC_FREQ_LONG
+              fits_keyword: TUNIT5
+            tunit6:
+              type: string
+              title: Column 6 units
+              default: ''
+              fits_hdu: RFC_FREQ_LONG
+              fits_keyword: TUNIT6
+            tunit7:
+              type: string
+              title: Column 7 units
+              default: cm^-1
+              fits_hdu: RFC_FREQ_LONG
+              fits_keyword: TUNIT7
+        max_amp:
+          type: object
+          title: Information about the fringe frequencies table
+          properties:
+            tunit1:
+              type: string
+              title: Column 1 units
+              default: micron
+              fits_hdu: MAX_AMP
+              fits_keyword: TUNIT1
+            tunit2:
+              type: string
+              title: Column 2 units
+              default: ''
+              fits_hdu: MAX_AMP
+              fits_keyword: TUNIT2
+    fringefreq_table_short:
+      title: Fringe frequencies table for SHORT
+      fits_hdu: RFC_FREQ_SHORT
       datatype:
-      - name: sub_band
-        datatype: [ascii, 16]
-      - name: wavenumber
+      - name: slice
         datatype: float64
-      - name: deltawavenumber
+      - name: ffreq
         datatype: float64
-      - name: maxamplitude
+      - name: dffreq
         datatype: float64
+      - name: min_nfringes
+        datatype: int64
+      - name: max_nfringes
+        datatype: int64
+      - name: min_snr
+        datatype: float64
+      - name: pgram_res
+        datatype: float64
+    fringefreq_table_medium:
+      title: Fringe frequencies table for MEDIUM
+      fits_hdu: RFC_FREQ_MEDIUM
+      datatype:
+      - name: slice
+        datatype: float64
+      - name: ffreq
+        datatype: float64
+      - name: dffreq
+        datatype: float64
+      - name: min_nfringes
+        datatype: int64
+      - name: max_nfringes
+        datatype: int64
+      - name: min_snr
+        datatype: float64
+      - name: pgram_res
+        datatype: float64
+    fringefreq_table_long:
+      title: Fringe frequencies table for LONG
+      fits_hdu: RFC_FREQ_LONG
+      datatype:
+      - name: slice
+        datatype: float64
+      - name: ffreq
+        datatype: float64
+      - name: dffreq
+        datatype: float64
+      - name: min_nfringes
+        datatype: int64
+      - name: max_nfringes
+        datatype: int64
+      - name: min_snr
+        datatype: float64
+      - name: pgram_res
+        datatype: float64
+    max_amp:
+      title: Maximum amplitude of residual fringes
+      fits_hdu: MAX_AMP
+      datatype:
+      - name: Wavelength
+        datatype: float64
+      - name: Amplitude
+        datatype: float64
+

--- a/miri/datamodels/tests/test_fringe_frequencies_model.py
+++ b/miri/datamodels/tests/test_fringe_frequencies_model.py
@@ -11,8 +11,9 @@ in the datamodels.miri_fringe_frequencies_model module.
 10 May 2017: Original version.
 12 Jul 2017: Replaced "clobber" parameter with "overwrite".
 17 Oct 2018: 'N/A' used as a metadata wildcard instead of 'ANY'.
+29 Apr 2021: updated the testing class to work with reformatted CDP
 
-@author: Steven Beard (UKATC)
+@author: Steven Beard (UKATC), Patrick Kavanagh (DIAS)
 
 """
 
@@ -33,12 +34,26 @@ class TestMiriMrsFringeFrequenciesModel(unittest.TestCase):
         
     def setUp(self):
         # Create a MiriFilter object containing test data
-        self.fringefreq_table = [('N/A', 11.0,  0.1, 42.0),
-                      ('N/A', 12.0,  0.2, 22.0),
-                      ('N/A', 13.0,  0.3, 32.0),
-                      ('N/A', 14.0,  0.4, 12.0)]
-        self.dataproduct = MiriMrsFringeFrequenciesModel( \
-                                    fringefreq_table=self.fringefreq_table)
+        fringefreqentry = [(101.0, np.array([2.9, 0]), np.array([0.3, 0]), np.array([5, 0]),
+                            np.array([30, 0]), np.array([10, 0]), np.array([0.005, 0])),
+                           (102.0, np.array([2.9, 0]), np.array([0.3, 0]), np.array([5, 0]),
+                            np.array([30, 0]), np.array([10, 0]), np.array([0.005, 0])),
+                           (103.0, np.array([2.9, 0]), np.array([0.3, 0]), np.array([5, 0]),
+                            np.array([30, 0]), np.array([10, 0]), np.array([0.005, 0])),
+                           (104.0, np.array([2.9, 0]), np.array([0.3, 0]), np.array([5, 0]),
+                            np.array([30, 0]), np.array([10, 0]), np.array([0.005, 0]))
+                           ]
+
+        # max_amp arrays
+        wav = np.linspace(4.0, 10.0, 20)
+        amp = np.ones(wav.shape) * 0.2
+        maxampentry = list(zip(wav.tolist(), amp.tolist()))
+
+        # test data
+        self.fringefreq_table = [fringefreqentry, fringefreqentry, fringefreqentry, maxampentry]
+
+        # load
+        self.dataproduct = MiriMrsFringeFrequenciesModel(fringefreq_table=self.fringefreq_table)
         # Add some typical metadata
         self.dataproduct.set_instrument_metadata(detector='MIRIFUSHORT',
                                          ccc_pos='OPEN', channel='N/A',
@@ -77,7 +92,7 @@ class TestMiriMrsFringeFrequenciesModel(unittest.TestCase):
         # Check that the field names in the class variable are the same
         # as the ones declared in the schema.
         class_names = list(MiriMrsFringeFrequenciesModel.fieldnames)
-        schema_names = list(self.dataproduct.get_field_names('fringefreq_table'))
+        schema_names = list(self.dataproduct.get_field_names('fringefreq_table_short'))
         self.assertEqual(class_names, schema_names,
                          "'fieldnames' class variable does not match schema")
  
@@ -100,11 +115,11 @@ class TestMiriMrsFringeFrequenciesModel(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             datacopy = self.dataproduct.copy()
-        self.assertIsNotNone(datacopy.fringefreq_table)
-        self.assertEqual( len(self.dataproduct.fringefreq_table),
-                          len(datacopy.fringefreq_table) )
-        table1 = np.asarray(self.dataproduct.fringefreq_table)
-        table2 = np.asarray(datacopy.fringefreq_table)
+        self.assertIsNotNone(datacopy.fringefreq_table_short)
+        self.assertEqual( len(self.dataproduct.fringefreq_table_short),
+                          len(datacopy.fringefreq_table_short) )
+        table1 = np.asarray(self.dataproduct.fringefreq_table_short)
+        table2 = np.asarray(datacopy.fringefreq_table_short)
         assert_recarray_equal(table1, table2)
         del datacopy
         
@@ -128,8 +143,19 @@ class TestMiriMrsFringeFrequenciesModel(unittest.TestCase):
             # file and read back again without changing the data.
             self.dataproduct.save(self.testfile, overwrite=True)
             with MiriMrsFringeFrequenciesModel(self.testfile) as readback:
+                # use the util to compare the max_amp_array
                 assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=[], tables='fringefreq_table' )
+                                       arrays=[], tables=['max_amp'])
+
+                # the fringe frequency arrays will fail the previous comparison
+                # as they contain nested arrays. Select specific array parts to compare
+                assert_recarray_equal(self.dataproduct.fringefreq_table_short.slice,
+                                  readback.fringefreq_table_short.slice)
+                assert_recarray_equal(self.dataproduct.fringefreq_table_medium.ffreq[0],
+                                      readback.fringefreq_table_medium.ffreq[0])
+                assert_recarray_equal(self.dataproduct.fringefreq_table_long.ffreq[-1],
+                                      readback.fringefreq_table_long.ffreq[-1])
+
                 del readback
 
 


### PR DESCRIPTION
This pull request contains changes to the miri fringe frequencies datamodel, yaml file and unit tests. The major changes are:

- datamodel now contains 3 frequency tables, one for each band with frequencies and fit parameters per slice on the detector
- the old max_amp parameter has been taken out of the original fringe frequencies table and moved into a fourth table to allow for a wavelength-dependent max_amp implementation
- this new four table structure is passed as a list of lists or recarrays to the constructor
- the tests in __main__ of the constructor have been updated
- unit tests have been updated to work with the new datamodel specifications
- the old test to compare arrays in test_fitsio does not work for the new fringe frequency tables as the contain nested arrays. The test now selects some columns or nested arrays to compare rather than the entire table
- relevant docstrings updated

Both the updated unit tests and residual fringe correction step tests using the CDP produced from the datamodel have passed with no issues.

@smbeard Since this is the first time I have directly modified a datamodel, it would be great if you could check that everything looks good. Just to make sure I haven't missed anything. Thanks!

