### PR TITLE
inclusion of lrs aperture, position and throughput correction in get_cdp

### DIFF
--- a/miri/datamodels/cdp.py
+++ b/miri/datamodels/cdp.py
@@ -79,6 +79,8 @@ http://ssb.stsci.edu/doc/jwst/jwst/introduction.html#crds-reference-files
              straylight model.
 12 Mar 2019: Added 'SPECWCS' as an alias for 'DISTORTION'.
 11 May 2020: CDP-3, CDP-6 and CDP-7 versions of data models removed.
+02 May 2021: Added LRS data models: aperture, position and throughput correction
+             models from module miri_aperture_correction_model.py
 
 @author: Steven Beard (UKATC), Vincent Geers (DIAS)
 
@@ -113,7 +115,8 @@ from miri.datamodels.miri_wavelength_correction_model import \
 from miri.datamodels.miri_spectral_spatial_resolution_model import \
     MiriMrsResolutionModel
 from miri.datamodels.miri_aperture_correction_model import \
-    MiriMrsApertureCorrectionModel
+    MiriMrsApertureCorrectionModel, MiriLrsApertureCorrectionModel, \
+    MiriLrsThroughputCorrectionModel, MiriLrsPositionCorrectionModel
 from miri.datamodels.miri_reset_switch_charge_decay_model import \
     MiriResetSwitchChargeDecayModel
 from miri.datamodels.miri_gain_model import MiriGainModel
@@ -210,6 +213,9 @@ CDP_DICT = { \
             'WAVCORR' : MiriMrsWavelengthCorrectionModel, \
             'RESOL'   : MiriMrsResolutionModel, \
             'APERCORR' : MiriMrsApertureCorrectionModel, \
+            'APCORR' : MiriLrsApertureCorrectionModel, \
+            'THROUGHCORR' : MiriLrsThroughputCorrectionModel, \
+            'POSCORR' : MiriLrsPositionCorrectionModel, \
             # -----------------------------------------------------------
             # Legacy Keywords and Data Products - Backwards Compatibility Only
             # The following section could be removed without affecting the

--- a/miri/datamodels/miri_aperture_correction_model.py
+++ b/miri/datamodels/miri_aperture_correction_model.py
@@ -325,7 +325,7 @@ class MiriLrsPositionCorrectionModel(MiriDataModel):
         super(MiriLrsPositionCorrectionModel, self).__init__(init=init, **kwargs)
 
         # Data type is position correction.
-        self.meta.reftype = 'POS_CORR'
+        self.meta.reftype = 'POSCORR'
         # Initialise the model type
         self._init_data_type()
         # This is a reference data model.

--- a/miri/datamodels/miri_aperture_correction_model.py
+++ b/miri/datamodels/miri_aperture_correction_model.py
@@ -359,7 +359,7 @@ if __name__ == '__main__':
     print("Testing the miri_aperture_correction_model module.")
     
     PLOTTING = False
-    SAVE_FILES = True
+    SAVE_FILES = False
 
     apercorrdata = [(5.0, 'nominal', 4.87,  7.76,  8.57, 1.0,  0.0, 42.0, 0.1),
                    (10.0, 'nominal', 5.87,  8.76,  9.57, 1.0,  0.0, 32.0, 0.1),

--- a/miri/datamodels/miri_aperture_correction_model.py
+++ b/miri/datamodels/miri_aperture_correction_model.py
@@ -264,8 +264,6 @@ class MiriLrsApertureCorrectionModel(MiriDataModel):
             
         # Copy the table column units from the schema, if defined.
         apcorr_units = self.set_table_units('apcorr_table')
-        self.set_fits_keyword("SIZEUNIT", "pixels", "APCORR")
-        self.set_fits_keyword("WAVEUNIT", "micron", "APCORR")
         
     def _init_data_type(self):
         # Initialise the data model type
@@ -361,7 +359,7 @@ if __name__ == '__main__':
     print("Testing the miri_aperture_correction_model module.")
     
     PLOTTING = False
-    SAVE_FILES = False
+    SAVE_FILES = True
 
     apercorrdata = [(5.0, 'nominal', 4.87,  7.76,  8.57, 1.0,  0.0, 42.0, 0.1),
                    (10.0, 'nominal', 5.87,  8.76,  9.57, 1.0,  0.0, 32.0, 0.1),

--- a/miri/datamodels/schemas/miri_position_correction_lrs.schema.yaml
+++ b/miri/datamodels/schemas/miri_position_correction_lrs.schema.yaml
@@ -14,20 +14,20 @@ allOf:
               type: string
               title: Column 1 units
               default: micron
-              fits_hdu: POS_CORR
+              fits_hdu: POSCORR
               fits_keyword: TUNIT1
             tunit2:
               type: string
               title: Column 2 units
               default: ''
-              fits_hdu: POS_CORR
+              fits_hdu: POSCORR
               fits_keyword: TUNIT2
 
 - type: object
   properties:
     poscorr_table:
       title: Position correction table
-      fits_hdu: POS_CORR
+      fits_hdu: POSCORR
       datatype:
       - name: wavelength
         datatype: float32

--- a/miri/datamodels/schemas/miri_throughput_correction_lrs.schema.yaml
+++ b/miri/datamodels/schemas/miri_throughput_correction_lrs.schema.yaml
@@ -14,25 +14,25 @@ allOf:
               type: string
               title: Column 1 units
               default: micron
-              fits_hdu: THROUGH_CORR
+              fits_hdu: THROUGHCORR
               fits_keyword: TUNIT1
             tunit2:
               type: string
               title: Column 2 units
               default: ''
-              fits_hdu: THROUGH_CORR
+              fits_hdu: THROUGHCORR
               fits_keyword: TUNIT2
             tunit3:
               type: string
               title: Column 3 units
               default: ''
-              fits_hdu: THROUGH_CORR
+              fits_hdu: THROUGHCORR
               fits_keyword: TUNIT3
 - type: object
   properties:
     throughcorr_table:
       title: Throughput correction table
-      fits_hdu: THROUGH_CORR
+      fits_hdu: THROUGHCORR
       datatype:
       - name: wavelength
         datatype: float32


### PR DESCRIPTION
I have added 3 new CDP datamodels to MiriTE, they are all defined in miri_aperture_correction_model.py along with their schemas in the schema directory.
To be able to load them once the fits files are on the CDP server, I have added the references to cdp.py: APCORR, THROUGHCORR and POSCORR.
Steven, would be good if you could check them. Thanks.
