### PR TITLE
MIRI-1156: updates for b7.8.2

### DIFF
--- a/miri/__init__.py
+++ b/miri/__init__.py
@@ -46,6 +46,8 @@ miri.simulators
 21 Jun 2018: Python 3 release (V7.1)
 10 Jun 2019: Modified data model schemas for JWST build 7.3 (V7.3)
 23 Mar 2019: Modified data models for JWST build 7.3 and Python 3.7 (V7.4)
+15 Sep 2021: Various updates for compatibility with newer JWST builds, now
+             up-to-date with JWST B7.8.
 
 @author: MIRI Software Team
 
@@ -54,4 +56,4 @@ __project__ = 'MIRI Tool and Environment Software'
 __author__ = 'MIRI Software Team'
 __maintainer__ = 'MIRI Software Team: mirisim@roe.ac.uk'
 __copyright__ = '2021, %s' % __author__
-__version__ = '7.4'
+__version__ = '7.8'

--- a/miri/datamodels/tests/test_dark_reference_model.py
+++ b/miri/datamodels/tests/test_dark_reference_model.py
@@ -39,6 +39,8 @@ in the datamodels.miri_dark_reference_model module.
 15 Nov 2018: Schema switched to use JWST darkMIRI.schema.
 07 Oct 2019: FIXME: dq_def removed from unit tests until data corruption
              bug fixed (Bug 589).
+15 Sep 2021: added dq_def back to unit tests after data corruption bug was
+             fixed (MIRI-1156).
 
 @author: Steven Beard (UKATC)
 
@@ -142,10 +144,7 @@ class TestMiriDarkReferenceModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                       tables='dq_def' )
+        assert_products_equal(self, self.dataproduct, datacopy, arrays=['data', 'err', 'dq'], tables='dq_def')
         del datacopy
         
     def test_fitsio(self):
@@ -157,10 +156,7 @@ class TestMiriDarkReferenceModel(unittest.TestCase):
             # file and read back again without changing the data.
             self.dataproduct.save(self.testfile, overwrite=True)
             with MiriDarkReferenceModel(self.testfile) as readback:
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                               tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
         
     def test_description(self):
@@ -184,6 +180,7 @@ class TestMiriDarkReferenceModel(unittest.TestCase):
         descr = str(self.dataproduct.dq)
         self.assertIsNotNone(descr)
         del descr
+
 
 # If being run as a main program, run the tests.
 if __name__ == '__main__':

--- a/miri/datamodels/tests/test_flatfield_model.py
+++ b/miri/datamodels/tests/test_flatfield_model.py
@@ -35,6 +35,8 @@ in the datamodels.miri_flatfield_model module.
              when the data model is saved to a file.
 07 Oct 2019: FIXME: dq_def removed from unit tests until data corruption
              bug fixed (Bug 589).
+15 Sep 2021: added dq_def back to unit tests after data corruption bug was
+             fixed (MIRI-1156).
 
 @author: Steven Beard (UKATC)
 
@@ -139,10 +141,7 @@ class TestMiriFlatfieldModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                       tables='dq_def' )
+        assert_products_equal(self, self.dataproduct, datacopy, arrays=['data', 'err', 'dq'], tables='dq_def')
         del datacopy
         
     def test_fitsio(self):
@@ -158,10 +157,7 @@ class TestMiriFlatfieldModel(unittest.TestCase):
                                  readback.meta.reftype)
                 self.assertEqual(self.dataproduct.meta.model_type,
                                  readback.meta.model_type)
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                               tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
         
     def test_description(self):
@@ -276,10 +272,7 @@ class TestMiriSkyFlatfieldModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                       tables='dq_def' )
+        assert_products_equal(self, self.dataproduct, datacopy, arrays=['data', 'err', 'dq'], tables='dq_def')
         del datacopy
         
     def test_fitsio(self):
@@ -295,10 +288,7 @@ class TestMiriSkyFlatfieldModel(unittest.TestCase):
                                  readback.meta.reftype)
                 self.assertEqual(self.dataproduct.meta.model_type,
                                  readback.meta.model_type)
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
         
     def test_description(self):
@@ -413,10 +403,7 @@ class TestMiriFringeFlatfieldModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                       tables='dq_def' )
+        assert_products_equal(self, self.dataproduct, datacopy, arrays=['data', 'err', 'dq'], tables='dq_def')
         del datacopy
         
     def test_fitsio(self):
@@ -432,10 +419,7 @@ class TestMiriFringeFlatfieldModel(unittest.TestCase):
                                  readback.meta.reftype)
                 self.assertEqual(self.dataproduct.meta.model_type,
                                  readback.meta.model_type)
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
         
     def test_description(self):
@@ -550,10 +534,7 @@ class TestMiriTargetFlatfieldModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                       tables='dq_def' )
+        assert_products_equal(self, self.dataproduct, datacopy, arrays=['data', 'err', 'dq'], tables='dq_def')
         del datacopy
         
     def test_fitsio(self):
@@ -569,10 +550,7 @@ class TestMiriTargetFlatfieldModel(unittest.TestCase):
                                  readback.meta.reftype)
                 self.assertEqual(self.dataproduct.meta.model_type,
                                  readback.meta.model_type)
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
         
     def test_description(self):

--- a/miri/datamodels/tests/test_fluxconversion_models.py
+++ b/miri/datamodels/tests/test_fluxconversion_models.py
@@ -34,6 +34,8 @@ in the datamodels.miri_fluxconversion_model module.
              when the data model is saved to a file.
 07 Oct 2019: FIXME: dq_def removed from unit tests until data corruption
              bug fixed (Bug 589).
+15 Sep 2021: added dq_def back to unit tests after data corruption bug was
+             fixed (MIRI-1156).
 
 @author: Steven Beard (UKATC)
 
@@ -610,10 +612,7 @@ class TestMiriMrsFluxconversionModel(unittest.TestCase):
                                  readback.meta.reftype)
                 self.assertEqual(self.dataproduct.meta.model_type,
                                  readback.meta.model_type)
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                               tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
         
     def test_description(self):

--- a/miri/datamodels/tests/test_lastframe_model.py
+++ b/miri/datamodels/tests/test_lastframe_model.py
@@ -13,6 +13,8 @@ in the datamodels.miri_lastframe_model module.
 12 Jul 2017: Replaced "clobber" parameter with "overwrite".
 07 Oct 2019: FIXME: dq_def removed from unit tests until data corruption
              bug fixed (Bug 589).
+15 Sep 2021: added dq_def back to unit tests after data corruption bug was
+             fixed (MIRI-1156).
 
 @author: Steven Beard (UKATC), Vincent Geers (DIAS)
 
@@ -80,10 +82,7 @@ class TestMiriLastFrameModel(unittest.TestCase):
             # file and read back again without changing the data.
             self.dataproduct.save(self.testfile, overwrite=True)
             with MiriLastFrameModel(self.testfile) as readback:
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
         
     def test_description(self):

--- a/miri/datamodels/tests/test_linearity_model.py
+++ b/miri/datamodels/tests/test_linearity_model.py
@@ -36,6 +36,8 @@ in the datamodels.miri_linearity_model module.
 12 Jul 2017: Replaced "clobber" parameter with "overwrite".
 07 Oct 2019: FIXME: dq_def removed from unit tests until data corruption
              bug fixed (Bug 589).
+15 Sep 2021: added dq_def back to unit tests after data corruption bug was
+             fixed (MIRI-1156).
 
 @author: Steven Beard (UKATC)
 
@@ -134,11 +136,7 @@ class TestMiriLinearityModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq'])
-#                                        'minimage', 'maximage', 'fiterr'],
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                       tables='dq_def' )
+        assert_products_equal(self, self.dataproduct, datacopy, arrays=['data', 'err', 'dq'], tables='dq_def')
         del datacopy
        
     def test_fitsio(self):
@@ -150,11 +148,7 @@ class TestMiriLinearityModel(unittest.TestCase):
             # file and read back again without changing the data.
             self.dataproduct.save(self.testfile, overwrite=True)
             with MiriLinearityModel(self.testfile) as readback:
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-#                                                'minimage', 'maximage', 'fiterr'],
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
         
     def test_description(self):

--- a/miri/datamodels/tests/test_measured_model.py
+++ b/miri/datamodels/tests/test_measured_model.py
@@ -65,6 +65,8 @@ in the datamodels.miri_measured_model module.
 07 Oct 2019: FIXME: dq_def removed from unit tests until data corruption
              bug fixed (Bug 589).
 12 Feb 2020: Reinstated the array broadcasting test.
+15 Sep 2021: added dq_def back to unit tests after data corruption bug was
+             fixed (MIRI-1156).
 
 @author: Steven Beard (UKATC)
 
@@ -334,10 +336,7 @@ class TestMiriMeasuredModel(unittest.TestCase):
 
             self.dataproduct.save(self.testfile2, overwrite=True)
             with MiriMeasuredModel(self.testfile2) as readback:
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
 
     def test_asciiio(self):
@@ -982,12 +981,11 @@ class TestMiriSlopeModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq',
-                                       'nreads', 'readsat', 'ngoodseg',
-                                       'zeropt', 'fiterr'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                       tables='dq_def' )
+        assert_products_equal(self, self.dataproduct, datacopy,
+                              arrays=['data', 'err', 'dq',
+                                      'nreads', 'readsat', 'ngoodseg',
+                                      'zeropt', 'fiterr'],
+                              tables='dq_def')
         del datacopy
 
     def test_fitsio(self):
@@ -999,12 +997,11 @@ class TestMiriSlopeModel(unittest.TestCase):
             # file and read back again without changing the data.
             self.dataproduct.save(self.testfile, overwrite=True)
             with MiriSlopeModel(self.testfile) as readback:
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq',
-                                               'nreads', 'readsat', 'ngoodseg',
-                                               'zeropt', 'fiterr'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback,
+                                      arrays=['data', 'err', 'dq',
+                                              'nreads', 'readsat', 'ngoodseg',
+                                              'zeropt', 'fiterr'],
+                                      tables='dq_def')
                 del readback
         
     def test_description(self):

--- a/miri/datamodels/tests/test_pixel_saturation_model.py
+++ b/miri/datamodels/tests/test_pixel_saturation_model.py
@@ -28,6 +28,8 @@ in the datamodels.miri_pixel_saturation_model module.
 12 Jul 2017: Replaced "clobber" parameter with "overwrite".
 07 Oct 2019: FIXME: dq_def removed from unit tests until data corruption
              bug fixed (Bug 589).
+15 Sep 2021: added dq_def back to unit tests after data corruption bug was
+             fixed (MIRI-1156).
 
 @author: Steven Beard (UKATC)
 
@@ -114,10 +116,7 @@ class TestMiriPixelSaturationModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                       tables='dq_def' )
+        assert_products_equal(self, self.dataproduct, datacopy, arrays=['data', 'err', 'dq'], tables='dq_def')
         del datacopy
         
     def test_fitsio(self):
@@ -129,10 +128,7 @@ class TestMiriPixelSaturationModel(unittest.TestCase):
             # file and read back again without changing the data.
             self.dataproduct.save(self.testfile, overwrite=True)
             with MiriPixelSaturationModel(self.testfile) as readback:
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
         
     def test_description(self):

--- a/miri/datamodels/tests/test_psf_models.py
+++ b/miri/datamodels/tests/test_psf_models.py
@@ -49,6 +49,8 @@ in the datamodels.miri_psf_model module.
              when the data model is saved to a file.
 07 Oct 2019: FIXME: dq_def removed from unit tests until data corruption
              bug fixed (Bug 589).
+15 Sep 2021: added dq_def back to unit tests after data corruption bug was
+             fixed (MIRI-1156).
 
 @author: Steven Beard (UKATC)
 
@@ -159,10 +161,7 @@ class TestMiriPointSpreadFunctionModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                       tables='dq_def' )
+        assert_products_equal(self, self.dataproduct, datacopy, arrays=['data', 'err', 'dq'], tables='dq_def')
         del datacopy
         
     def test_fitsio(self):
@@ -176,10 +175,7 @@ class TestMiriPointSpreadFunctionModel(unittest.TestCase):
             with MiriPointSpreadFunctionModel(self.testfile) as readback:
                 self.assertEqual(self.dataproduct.meta.reftype,
                                  readback.meta.reftype)
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
         
     def test_description(self):
@@ -283,11 +279,8 @@ class TestMiriImagingPointSpreadFunctionModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq'],
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                      tables=['dq_def', 'psf_lut'] )
-                               tables=['psf_lut'] )
+        assert_products_equal(self, self.dataproduct, datacopy, arrays=['data', 'err', 'dq'],
+                              tables=['dq_def', 'psf_lut'])
         del datacopy
         
     def test_fitsio(self):
@@ -303,11 +296,8 @@ class TestMiriImagingPointSpreadFunctionModel(unittest.TestCase):
                                  readback.meta.reftype)
                 self.assertEqual(self.dataproduct.meta.model_type,
                                  readback.meta.model_type)
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'],
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables=['dq_def', 'psf_lut'] )
-                                       tables=['psf_lut'] )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'],
+                                      tables=['dq_def', 'psf_lut'])
                 del readback
 
             # Check that other variations of the data product can be
@@ -329,11 +319,8 @@ class TestMiriImagingPointSpreadFunctionModel(unittest.TestCase):
             with MiriImagingPointSpreadFunctionModel(self.testfile) as readback:
                 self.assertEqual(testproduct.meta.reftype,
                                  readback.meta.reftype)
-                assert_products_equal( self, testproduct, readback,
-                                       arrays=['data', 'err', 'dq'],
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-#                                       tables=['dq_def', 'psf_lut'] )
-                                       tables=['psf_lut'] )
+                assert_products_equal(self, testproduct, readback, arrays=['data', 'err', 'dq'],
+                                      tables=['dq_def', 'psf_lut'])
                 del readback
         
     def test_description(self):
@@ -421,10 +408,7 @@ class TestMiriLrsPointSpreadFunctionModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                       tables=['dq_def'] )
+        assert_products_equal(self, self.dataproduct, datacopy, arrays=['data', 'err', 'dq'], tables=['dq_def'])
         del datacopy
 
     def test_fitsio(self):
@@ -440,10 +424,7 @@ class TestMiriLrsPointSpreadFunctionModel(unittest.TestCase):
                                  readback.meta.reftype)
                 self.assertEqual(self.dataproduct.meta.model_type,
                                  readback.meta.model_type)
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables=['dq_def'] )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables=['dq_def'])
                 del readback
 
             # Check that other variations of the data product can be
@@ -459,10 +440,7 @@ class TestMiriLrsPointSpreadFunctionModel(unittest.TestCase):
             with MiriLrsPointSpreadFunctionModel(self.testfile) as readback:
                 self.assertEqual(testproduct.meta.reftype,
                                  readback.meta.reftype)
-                assert_products_equal( self, testproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables=['dq_def',] )
+                assert_products_equal(self, testproduct, readback, arrays=['data', 'err', 'dq'], tables=['dq_def'])
                 del readback
 
     def test_description(self):
@@ -547,10 +525,7 @@ class TestMiriMrsPointSpreadFunctionModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                       tables=['dq_def'] )
+        assert_products_equal(self, self.dataproduct, datacopy, arrays=['data', 'err', 'dq'], tables=['dq_def'])
         del datacopy
         
     def test_fitsio(self):
@@ -566,10 +541,7 @@ class TestMiriMrsPointSpreadFunctionModel(unittest.TestCase):
                                  readback.meta.reftype)
                 self.assertEqual(self.dataproduct.meta.model_type,
                                  readback.meta.model_type)
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables=['dq_def'] )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables=['dq_def'])
                 del readback
         
     def test_description(self):

--- a/miri/datamodels/tests/test_reset_model.py
+++ b/miri/datamodels/tests/test_reset_model.py
@@ -13,6 +13,8 @@ in the datamodels.miri_reset_model module.
 12 Jul 2017: Replaced "clobber" parameter with "overwrite".
 07 Oct 2019: FIXME: dq_def removed from unit tests until data corruption
              bug fixed (Bug 589).
+15 Sep 2021: added dq_def back to unit tests after data corruption bug was
+             fixed (MIRI-1156).
 
 @author: Steven Beard (UKATC), Vincent Geers (DIAS)
 
@@ -94,10 +96,7 @@ class TestMiriResetModel(unittest.TestCase):
             # file and read back again without changing the data.
             self.dataproduct.save(self.testfile, overwrite=True)
             with MiriResetModel(self.testfile) as readback:
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
         
     def test_description(self):

--- a/miri/datamodels/tests/test_telescope_emission_model.py
+++ b/miri/datamodels/tests/test_telescope_emission_model.py
@@ -30,6 +30,8 @@ in the datamodels.miri_telescope_emission_model module.
 12 Jul 2017: Replaced "clobber" parameter with "overwrite".
 07 Oct 2019: FIXME: dq_def removed from unit tests until data corruption
              bug fixed (Bug 589).
+15 Sep 2021: added dq_def back to unit tests after data corruption bug was
+             fixed (MIRI-1156).
 
 @author: Steven Beard (UKATC)
 
@@ -117,10 +119,7 @@ class TestMiriTelescopeEmissionModel(unittest.TestCase):
         # Test that a copy can be made of the data product.
         datacopy = self.dataproduct.copy()
         self.assertIsNotNone(datacopy)
-        assert_products_equal( self, self.dataproduct, datacopy,
-                               arrays=['data', 'err', 'dq'])
-        # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-        #                       tables='dq_def' )
+        assert_products_equal(self, self.dataproduct, datacopy, arrays=['data', 'err', 'dq'], tables='dq_def')
         del datacopy
         
     def test_fitsio(self):
@@ -132,10 +131,7 @@ class TestMiriTelescopeEmissionModel(unittest.TestCase):
             # file and read back again without changing the data.
             self.dataproduct.save(self.testfile, overwrite=True)
             with MiriTelescopeEmissionModel(self.testfile) as readback:
-                assert_products_equal( self, self.dataproduct, readback,
-                                       arrays=['data', 'err', 'dq'])
-                # FIXME: removed dq_def until data corruption bug fixed. Bug 589
-                #                       tables='dq_def' )
+                assert_products_equal(self, self.dataproduct, readback, arrays=['data', 'err', 'dq'], tables='dq_def')
                 del readback
         
     def test_description(self):

--- a/miri/datamodels/tests/test_util.py
+++ b/miri/datamodels/tests/test_util.py
@@ -14,6 +14,8 @@ Simple tests of the data model utility functions in datamodels/util.py.
 04 Oct 2019: BUG IN DQ_DEF!! Disabled verify_cdp
 07 Oct 2019: FIXME: test_verify_cdp_file removed from unit tests until
              data corruption bug fixed (Bug 589).
+15 Sep 2021: re-instated test_verify_cdp_file after data corruption bug was
+             fixed (MIRI-1156).
 
 @author: Steven Beard (UKATC)
 
@@ -21,7 +23,6 @@ Simple tests of the data model utility functions in datamodels/util.py.
 
 import os
 import unittest
-import numpy as np
 
 import astropy.io.fits as pyfits
 
@@ -30,6 +31,7 @@ import miri.datamodels.cdp as cdp
 import miri.datamodels.sim as sim
 
 KEEPFILES = False
+
 
 class TestFileIO(unittest.TestCase):
     
@@ -135,10 +137,9 @@ class TestFileIO(unittest.TestCase):
     def test_verify_cdp_file(self):
         # Check that the CDP verification function passes the simple
         # files created by this test.
-        print("test_verify_cdp_file disabled due to dq_def corruption bug (589)!")
-        # FIXME: Track down the source of the dq_def corruption bug Bug 589
-        #for (filename, datamodel) in self.cdp_models_to_test:
-        #    util.verify_cdp_file(filename, overwrite=True)
+        for (filename, datamodel) in self.cdp_models_to_test:
+            util.verify_cdp_file(filename, overwrite=True)
+
 
 # If being run as a main program, run the tests.
 if __name__ == '__main__':


### PR DESCRIPTION
This PR is to add changes in response to the update to "jwst" B7.8.2, including:
- reinstating dq_def related tests in datamodel unit tests
- bumping up package version to 7.8