### PR TITLE
MIRI-1219: Added FASTR1 and SLOWR1 to the list of allowed readout mod…

### DIFF
--- a/miri/datamodels/schemas/miri_metadata.schema.yaml
+++ b/miri/datamodels/schemas/miri_metadata.schema.yaml
@@ -199,7 +199,7 @@ properties:
       readpatt:
         type: string
         title: Readout pattern
-        enum: [FAST, FASTGRPAVG, FASTINTAVG, SLOW, ANY, N/A]
+        enum: [FAST, FASTR1, FASTGRPAVG, FASTINTAVG, SLOW, SLOWR1, ANY, N/A]
         fits_keyword: READPATT
       nframes:
         type: integer


### PR DESCRIPTION
A trivial update which should fix the problem described in MIRI-1219. The schema file miri_metadata.schema.yaml verifies the metadata contained in a MIRI data model. The list of allowed values for the "metadata.readpatt" item had not been updated to include the new FASTR1 and SLOWR1 readout modes.

      readpatt:
        type: string
        title: Readout pattern
        enum: [FAST, **FASTR1**, FFASTGRPAVG, FASTINTAVG, SLOW, **SLOWR1**, ANY, N/A]
        fits_keyword: READPATT

This branch adds those modes to the list and should solve the errors described in MIRI-1219.
