### PR TITLE
Implement FASTR1 and SLOWR1 in miri datamodel as valid data.

### DIFF
--- a/miri/datamodels/schemas/miri_metadata.schema.yaml
+++ b/miri/datamodels/schemas/miri_metadata.schema.yaml
@@ -199,7 +199,7 @@ properties:
       readpatt:
         type: string
         title: Readout pattern
-        enum: [FAST, FASTGRPAVG, FASTINTAVG, SLOW, ANY, N/A]
+        enum: [FAST, FASTR1, FASTGRPAVG, FASTINTAVG, SLOW, SLOWR1, ANY, N/A]
         fits_keyword: READPATT
       nframes:
         type: integer


### PR DESCRIPTION
used to create the Imager CDP files. 

When I create the CDP datamodel, it gives a warning because FASTR1 is not in the list of valid values for READPATT. But the cdp is successfully created. 

However, the READPATT keyword doesn't exist in the created FITS file and cdp_verify complain about this.

This change solve the issue and the READPATT metadata is correctly created. then cdp_verify validate this CDP.